### PR TITLE
Hotfix/dtos

### DIFF
--- a/apps/backend/src/infrastructure/repositories/member.repository.impl.test.ts
+++ b/apps/backend/src/infrastructure/repositories/member.repository.impl.test.ts
@@ -3,7 +3,7 @@ import { MongoMemoryServer } from 'mongodb-memory-server';
 import mongoose, { Types } from 'mongoose';
 import { MemberModel } from '../database/mongo/models/member.model';
 import { MongoMemberRepository } from './member.repository.impl';
-import { Member } from '../../../../../domain/src/entities/Member';
+import { CreateMemberDTO, Member } from '../../../../../domain/src/entities/Member';
 
 describe("MongoMemberRepository", () => {
     let mongoServer: MongoMemoryServer;
@@ -185,5 +185,31 @@ describe("MongoMemberRepository", () => {
         await expect(repository.save(fakeMember))
             .rejects
             .toThrow(`Member with id ${fakeMember.id} not found`);
+    });
+
+    describe("Create method .-", () => {
+        test("create - new member with valid data returns saved member", async () => {
+            const newMemberDTO: CreateMemberDTO = {
+                firstName: "Jon",
+                lastName: "Snow",
+                email: "jon@winterfell.com",
+                weight: 75,
+                age: 25,
+                joinDate: new Date("2025-01-15"),
+            };
+    
+            await MemberModel.deleteMany({});
+            const result = await repository.create(newMemberDTO);
+    
+            expect(result.id).toBeDefined();
+            expect(result.firstName).toBe("Jon");
+            expect(result.lastName).toBe("Snow");
+            expect(result.email).toBe("jon@winterfell.com");
+            expect(result.weight).toBe(75);
+            expect(result.age).toBe(25);
+            expect(result.joinDate).toEqual(new Date("2025-01-15"));
+            expect(result.membershipStatus).toBe("inactive");
+            expect(result.paidUntil).toEqual(new Date(0));
+        });
     });
 });

--- a/apps/backend/src/infrastructure/repositories/member.repository.impl.test.ts
+++ b/apps/backend/src/infrastructure/repositories/member.repository.impl.test.ts
@@ -343,5 +343,37 @@ describe("MongoMemberRepository", () => {
             expect(foundInDb?.membershipStatus).toBe("active");
             expect(foundInDb?.lastName).toBe("Stark"); // Unchanged
         });
+
+        test("update - non-existent member throws error", async () => {
+            const fakeId = new Types.ObjectId().toString();
+            const updates: UpdateMemberDTO = {
+                firstName: "Ghost",
+            };
+
+            await MemberModel.deleteMany({});
+
+            await expect(repository.update(fakeId, updates))
+                .rejects
+                .toThrow(`Member with id ${fakeId} not found`);
+        });
+
+        test("update - empty updates object returns unchanged member", async () => {
+            const originalMember: CreateMemberDTO = {
+                firstName: "Rickon",
+                lastName: "Stark",
+                email: "rickon@winterfell.com",
+                weight: 45,
+                age: 12,
+                joinDate: new Date("2024-01-01"),
+            };
+
+            await MemberModel.deleteMany({});
+            const savedMember = await repository.create(originalMember);
+
+            const emptyUpdates: UpdateMemberDTO = {};
+            const result = await repository.update(savedMember.id, emptyUpdates);
+
+            expect(result).toEqual(savedMember);
+        });
     });
 });

--- a/apps/backend/src/infrastructure/repositories/member.repository.impl.test.ts
+++ b/apps/backend/src/infrastructure/repositories/member.repository.impl.test.ts
@@ -232,5 +232,22 @@ describe("MongoMemberRepository", () => {
             expect(foundInDb?.email).toBe("arya@winterfell.com");
             expect(foundInDb?.membershipStatus).toBe("inactive");
         });
+
+        test("create - sets default values correctly", async () => {
+            const newMemberDTO: CreateMemberDTO = {
+                firstName: "Sansa",
+                lastName: "Stark",
+                email: "sansa@winterfell.com",
+                weight: 60,
+                age: 22,
+                joinDate: new Date(),
+            };
+
+            await MemberModel.deleteMany({});
+            const result = await repository.create(newMemberDTO);
+
+            expect(result.membershipStatus).toBe("inactive");
+            expect(result.paidUntil.getTime()).toBe(0); // new Date(0)
+        });
     });
 });

--- a/apps/backend/src/infrastructure/repositories/member.repository.impl.test.ts
+++ b/apps/backend/src/infrastructure/repositories/member.repository.impl.test.ts
@@ -197,10 +197,10 @@ describe("MongoMemberRepository", () => {
                 age: 25,
                 joinDate: new Date("2025-01-15"),
             };
-    
+
             await MemberModel.deleteMany({});
             const result = await repository.create(newMemberDTO);
-    
+
             expect(result.id).toBeDefined();
             expect(result.firstName).toBe("Jon");
             expect(result.lastName).toBe("Snow");
@@ -210,6 +210,27 @@ describe("MongoMemberRepository", () => {
             expect(result.joinDate).toEqual(new Date("2025-01-15"));
             expect(result.membershipStatus).toBe("inactive");
             expect(result.paidUntil).toEqual(new Date(0));
+        });
+
+        test("create - member is persisted in database", async () => {
+            const newMemberDTO: CreateMemberDTO = {
+                firstName: "Arya",
+                lastName: "Stark",
+                email: "arya@winterfell.com",
+                weight: 55,
+                age: 18,
+                joinDate: new Date("2025-02-20"),
+            };
+
+            await MemberModel.deleteMany({});
+            const savedMember = await repository.create(newMemberDTO);
+
+            // Verify it's actually in the database
+            const foundInDb = await MemberModel.findById(savedMember.id);
+            expect(foundInDb).not.toBeNull();
+            expect(foundInDb?.firstName).toBe("Arya");
+            expect(foundInDb?.email).toBe("arya@winterfell.com");
+            expect(foundInDb?.membershipStatus).toBe("inactive");
         });
     });
 });

--- a/apps/backend/src/infrastructure/repositories/member.repository.impl.test.ts
+++ b/apps/backend/src/infrastructure/repositories/member.repository.impl.test.ts
@@ -3,7 +3,7 @@ import { MongoMemoryServer } from 'mongodb-memory-server';
 import mongoose, { Types } from 'mongoose';
 import { MemberModel } from '../database/mongo/models/member.model';
 import { MongoMemberRepository } from './member.repository.impl';
-import { CreateMemberDTO, Member } from '../../../../../domain/src/entities/Member';
+import { CreateMemberDTO, Member, UpdateMemberDTO } from '../../../../../domain/src/entities/Member';
 
 describe("MongoMemberRepository", () => {
     let mongoServer: MongoMemoryServer;
@@ -248,6 +248,43 @@ describe("MongoMemberRepository", () => {
 
             expect(result.membershipStatus).toBe("inactive");
             expect(result.paidUntil.getTime()).toBe(0); // new Date(0)
+        });
+    });
+
+    describe("Update method .-", () => {
+        test("update - existing member with valid updates returns updated member", async () => {
+            // First create a member
+            const originalMember: CreateMemberDTO = {
+                firstName: "Bran",
+                lastName: "Stark",
+                email: "bran@winterfell.com",
+                weight: 50,
+                age: 16,
+                joinDate: new Date("2025-01-01"),
+            };
+    
+            await MemberModel.deleteMany({});
+            const savedMember = await repository.create(originalMember);
+    
+            // Now update it
+            const updates: UpdateMemberDTO = {
+                firstName: "Brandon",
+                weight: 55,
+                membershipStatus: "active",
+                paidUntil: new Date("2025-12-31"),
+            };
+    
+            const result = await repository.update(savedMember.id, updates);
+    
+            expect(result.id).toBe(savedMember.id);
+            expect(result.firstName).toBe("Brandon"); // Updated
+            expect(result.lastName).toBe("Stark"); // Unchanged
+            expect(result.email).toBe("bran@winterfell.com"); // Unchanged
+            expect(result.weight).toBe(55); // Updated
+            expect(result.age).toBe(16); // Unchanged
+            expect(result.membershipStatus).toBe("active"); // Updated
+            expect(result.paidUntil).toEqual(new Date("2025-12-31")); // Updated
+            expect(result.joinDate).toEqual(new Date("2025-01-01")); // Unchanged (can't be updated)
         });
     });
 });

--- a/apps/backend/src/infrastructure/repositories/member.repository.impl.test.ts
+++ b/apps/backend/src/infrastructure/repositories/member.repository.impl.test.ts
@@ -262,10 +262,10 @@ describe("MongoMemberRepository", () => {
                 age: 16,
                 joinDate: new Date("2025-01-01"),
             };
-    
+
             await MemberModel.deleteMany({});
             const savedMember = await repository.create(originalMember);
-    
+
             // Now update it
             const updates: UpdateMemberDTO = {
                 firstName: "Brandon",
@@ -273,9 +273,9 @@ describe("MongoMemberRepository", () => {
                 membershipStatus: "active",
                 paidUntil: new Date("2025-12-31"),
             };
-    
+
             const result = await repository.update(savedMember.id, updates);
-    
+
             expect(result.id).toBe(savedMember.id);
             expect(result.firstName).toBe("Brandon"); // Updated
             expect(result.lastName).toBe("Stark"); // Unchanged
@@ -285,6 +285,36 @@ describe("MongoMemberRepository", () => {
             expect(result.membershipStatus).toBe("active"); // Updated
             expect(result.paidUntil).toEqual(new Date("2025-12-31")); // Updated
             expect(result.joinDate).toEqual(new Date("2025-01-01")); // Unchanged (can't be updated)
+        });
+
+        test("update - partial updates only change specified fields", async () => {
+            const originalMember: CreateMemberDTO = {
+                firstName: "Catelyn",
+                lastName: "Stark",
+                email: "catelyn@winterfell.com",
+                weight: 65,
+                age: 40,
+                joinDate: new Date("2025-01-01"),
+            };
+
+            await MemberModel.deleteMany({});
+            const savedMember = await repository.create(originalMember);
+
+            // Update only weight and status
+            const updates: UpdateMemberDTO = {
+                weight: 63,
+                membershipStatus: "active",
+            };
+
+            const result = await repository.update(savedMember.id, updates);
+
+            expect(result.firstName).toBe("Catelyn"); // Unchanged
+            expect(result.lastName).toBe("Stark"); // Unchanged
+            expect(result.email).toBe("catelyn@winterfell.com"); // Unchanged
+            expect(result.weight).toBe(63); // Updated
+            expect(result.age).toBe(40); // Unchanged
+            expect(result.membershipStatus).toBe("active"); // Updated
+            expect(result.paidUntil).toEqual(new Date(0)); // Unchanged
         });
     });
 });

--- a/apps/backend/src/infrastructure/repositories/member.repository.impl.test.ts
+++ b/apps/backend/src/infrastructure/repositories/member.repository.impl.test.ts
@@ -316,5 +316,32 @@ describe("MongoMemberRepository", () => {
             expect(result.membershipStatus).toBe("active"); // Updated
             expect(result.paidUntil).toEqual(new Date(0)); // Unchanged
         });
+
+        test("update - changes are persisted in database", async () => {
+            const originalMember: CreateMemberDTO = {
+                firstName: "Robb",
+                lastName: "Stark",
+                email: "robb@winterfell.com",
+                weight: 80,
+                age: 20,
+                joinDate: new Date(),
+            };
+
+            await MemberModel.deleteMany({});
+            const savedMember = await repository.create(originalMember);
+
+            const updates: UpdateMemberDTO = {
+                firstName: "Rob",
+                membershipStatus: "active",
+            };
+
+            await repository.update(savedMember.id, updates);
+
+            // Verify changes in database
+            const foundInDb = await MemberModel.findById(savedMember.id);
+            expect(foundInDb?.firstName).toBe("Rob");
+            expect(foundInDb?.membershipStatus).toBe("active");
+            expect(foundInDb?.lastName).toBe("Stark"); // Unchanged
+        });
     });
 });

--- a/apps/backend/src/infrastructure/repositories/member.repository.impl.ts
+++ b/apps/backend/src/infrastructure/repositories/member.repository.impl.ts
@@ -26,7 +26,27 @@ export class MongoMemberRepository implements MemberRepository {
   }
 
   async update(memberId: string, updates: UpdateMemberDTO): Promise<Member> {
- 
+    const saved = await MemberModel.findByIdAndUpdate(
+      memberId,
+      updates,
+      { new: true }
+    );
+    
+    if (!saved) {
+      throw new Error(`Member with id ${memberId} not found`);
+    }
+
+    return {
+      id: saved._id.toString(),
+      firstName: saved.firstName,
+      lastName: saved.lastName,
+      email: saved.email,
+      weight: saved.weight,
+      age: saved.age,
+      joinDate: saved.joinDate,
+      membershipStatus: saved.membershipStatus,
+      paidUntil: saved.paidUntil
+    };
   }
 
   async save(member: CreateMemberDTO | Member): Promise<Member> {

--- a/domain/src/repositories/member-repository.ts
+++ b/domain/src/repositories/member-repository.ts
@@ -1,6 +1,8 @@
-import { CreateMemberDTO, Member } from "../entities/Member";
+import { CreateMemberDTO, Member, UpdateMemberDTO } from "../entities/Member";
 
 export interface MemberRepository {
+  create(member: CreateMemberDTO): Promise<Member>;
+  update(memberId: string, updates: UpdateMemberDTO): Promise<Member>;
   save(member: CreateMemberDTO): Promise<Member>;
   findById(id: string): Promise<Member | null>;
   findByEmail(email: string): Promise<Member | null>;

--- a/domain/src/use-cases/members/register-member.ts
+++ b/domain/src/use-cases/members/register-member.ts
@@ -26,7 +26,7 @@ export async function RegisterMember(
     paidUntil: INITIAL_PAID_UNTIL,
   };
 
-  return members.save(member);
+  return members.create(member);
 }
 
 function validateData(dto: CreateMemberDTO): InvalidDataError | void {


### PR DESCRIPTION
# Member Repository Refactor for consistency whit DTOs

## Overview
This PR introduces a new interface for `MemberRepository` with dedicated `create` and `update` methods, along with implementations in both MongoDB and mock repositories. It also updates all affected use cases and tests.

## Changes

### 1. New MemberRepository Interface
- Added `create(member: CreateMemberDTO): Promise<Member>` for creating new members
- Added `update(memberId: string, updates: UpdateMemberDTO): Promise<Member>` for updating existing members
- Maintained `save()` for backward compatibility (delegates to `create` or `update` based on ID presence)

### 2. MongoMemberRepository Implementation
- Implemented `create()` for inserting new members
- Implemented `update()` for modifying existing members using `UpdateMemberDTO`
- Refactored `save()` to use the appropriate method (`create` or `update`)

### 3. Updated Mock Repository
- Implemented `create()` and `update()` consistent with the new interface
- Maintained existing delay simulation logic

### 4. Use Case Updates
- `RegisterMember`: now uses `create()`
- `ProcessPayment`: now uses `update()`
- `ChangeMemberStatus`: now uses `update()`
- `VerifyMembershipStatus`: now uses `update()`

### 5. Test Updates
- Updated all tests to use the new methods
- Verified all test cases pass
- Added new test cases for edge scenarios